### PR TITLE
Freeze xschem to version 3.4.6

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Install xschem
         run: |
           cd ${{ env.git }}
-          git clone --depth 1 https://github.com/StefanSchippers/xschem.git
+          git clone --branch 3.4.6 --depth 1 https://github.com/StefanSchippers/xschem.git
           cd xschem
           ./configure --prefix=${{ env.tools }}/xschem
           make -j`nproc`


### PR DESCRIPTION
Fixes the text issue by reverting to commit 49889ef00f5e4be7bcdc88bdf94ab9114eef7aeb in this repo and then adding a tag to the clone command for xschem in the github action. Tested locally and in a github act runner.